### PR TITLE
Add FreeBSD case in gcc.sh and change shebang to run wherever bash is installed.

### DIFF
--- a/gcc.sh
+++ b/gcc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ROOT="$(cd `dirname $0` && pwd)"
 
 if [ "`uname`" == "Linux" ]
@@ -7,6 +7,9 @@ then
 elif [ "`uname`" == "Darwin" ]
 then
 	compiler="x86_64-elf-gcc"
+elif [ "`uname`" == "FreeBSD" ]
+then
+	compiler="gcc"
 else
 	echo "$0: `uname` not supported"
 	exit 1


### PR DESCRIPTION
This Pull request is very small but this change is required when building redox-os/redox on FreeBSD.
This patch also helps other environments that places bash on where else of `/bin` (such like `/usr/bin`, `/usr/local/bin` or in-`busybox`, wherever).

I've confirmed that this works on Arch Linux, Ubuntu and FreeBSD (I assumed that `env` is on `/usr/`, but this seems to be common on such distro or OS).